### PR TITLE
Bundle the program into a windows executable using pyinstaller and github Actions

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -16,12 +16,20 @@ jobs:
         with:
           repository: CookiePLMonster/GTModTools
           path: gttools
+      - name: Checkout PyInstaller
+        uses: actions/checkout@v2
+        with:
+          repository: pyinstaller/pyinstaller
+          path: custom_pyinstaller
+          ref: v4.9
       - name: Setup python 3.10
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - name: Install pyinstaller from PyPI
-        run: pip install pyinstaller==4.9
+      - name: Compile pyinstaller from source
+        run: cd custom_pyinstaller/bootloader && python ./waf all --target-arch=64bit
+      - name: Install pyinstaller
+        run: pip install wheel && cd custom_pyinstaller && python setup.py install
       - name: Package into a one file executable
         run: pyinstaller -F setup.py -n gt2_discs_combiner
       - name: Copy resources into /dist

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,34 @@
+name: Build a one-file executable
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  Windows-Build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout the GTModTools
+        uses: actions/checkout@v2
+        with:
+          repository: CookiePLMonster/GTModTools
+          path: gttools
+      - name: Setup python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install pyinstaller from PyPI
+        run: pip install pyinstaller==4.9
+      - name: Package into a one file executable
+        run: pyinstaller -F setup.py -n gt2_discs_combiner
+      - name: Copy resources into /dist
+        run: foreach ($directory in ("menu_entries", "tools", "vol_replacements")) { Xcopy /E /I $directory dist\$directory }
+      - name: Package the build into a zip file
+        run: tar -c -f gt2_discs_combiner.zip -C dist *
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: gt2_discs_combiner.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 /.vscode/
+
+# Python
+__pycache__
+.mypy_cache
+
+# Build artefacts
+Build
+dist

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,13 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 def getResourcePath(path):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+    if getattr(sys, 'frozen', False):
+        # For frozen one-file executable
+        application_path = os.path.dirname(sys.executable)
+    else:
+        application_path = os.path.dirname(os.path.realpath(__file__))
+
+    return os.path.join(application_path, path)
 
 def main():
     # Utils


### PR DESCRIPTION
Setup a github actions workflow to bundle the python source code into a windows executable and automatically makes a release to remove the need to install python on the user's computer. Could be expanded to build Linux and MacOS executables. I made it so that the workflow only executes on tags.

I needed to change `getResourcePath` so that program looks for the resources files in the same directory as the generated one-file executable, the behavior is the same as before if executed as a script.

Link to an example of a release on my fork: https://github.com/amine4567/GT2-Combined-Disc/releases/tag/0.0.0.dev1